### PR TITLE
Update restapi_invoker.py

### DIFF
--- a/bitcom/connection/impl/restapi_invoker.py
+++ b/bitcom/connection/impl/restapi_invoker.py
@@ -14,7 +14,7 @@ def call_sync(request, is_checked=False):
         if is_checked is True:
             return response.text
         try:
-            dict_data = json.loads(response.text, encoding="utf-8")
+            dict_data = json.loads(response.text)
         except Exception as ex:
             print("recv error: ", response.text, "\nexception: ", ex)
             return
@@ -23,7 +23,7 @@ def call_sync(request, is_checked=False):
     elif request.method == "POST":
         response = session.post(request.host + request.url, data=json.dumps(request.post_body), headers=request.header)
         try:
-            dict_data = json.loads(response.text, encoding="utf-8")
+            dict_data = json.loads(response.text)
         except Exception as ex:
             print("recv error: ", response.text, "\nexception: ", ex)
             return


### PR DESCRIPTION
Upgrade bitcom to be compatible with python 3.9x (the keyword argument 'encoding' was removed from json.loads() in Python 3.9)

Remove encoding="utf-8" from restapi_invoker.py (json.loads call) as this generates the following exception: exception:  __init__() got an unexpected keyword argument 'encoding'.